### PR TITLE
Add Roundtable MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The list is automatically updated daily with the latest server information and G
 | **[Mysql (@benborla)](<https://github.com/benborla/mcp-server-mysql>)** | MCP server for providing read-only access to MySQL databases, enabling schema inspection and query execution. | ⭐ 1299 | 2026-03-09T12:19:28Z |
 | **[Qdrant (@qdrant)](<https://github.com/qdrant/mcp-server-qdrant>)** | This repository is an example of how to create a MCP server for Qdrant, a vector search engine. | ⭐ 1269 | 2026-03-09T08:59:38Z |
 | **[Terraform Server (@hashicorp)](<https://github.com/hashicorp/terraform-mcp-server>)** | Seamlessly integrate with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development powered by [Terraform](https://www.hashicorp.com/en/products/terraform) | ⭐ 1265 | 2026-03-07T16:22:23Z |
-| **[Roundtable (@sinaneshat)](<https://github.com/sinaneshat/roundtable-dashboard>)** | Multi-model AI debate platform — GPT-4o, Claude, Gemini & 200+ models discuss your prompt, then a moderator synthesizes insight. MCP tools: `consult`, `review_code`, `debug`, `architect`, `plan_implementation`, `assess_tradeoffs`. | ⭐ 0 | 2026-03-10T12:00:00Z |
+| **[Roundtable (@sinaneshat)](<https://github.com/sinaneshat/roundtable-dashboard>)** | Multi-model AI debate platform — GPT-4o, Claude, Gemini & 200+ models discuss your prompt, then a moderator synthesizes insight. MCP tools: `consult_council`, `review_code`, `debug_issue`, `design_architecture`, `plan_implementation`, `assess_tradeoffs`. | ⭐ 0 | 2026-03-10T12:37:47Z |
 
 ## Community
 * [Reddit r/mcp](https://www.reddit.com/r/mcp)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The list is automatically updated daily with the latest server information and G
 | **[Mysql (@benborla)](<https://github.com/benborla/mcp-server-mysql>)** | MCP server for providing read-only access to MySQL databases, enabling schema inspection and query execution. | ⭐ 1299 | 2026-03-09T12:19:28Z |
 | **[Qdrant (@qdrant)](<https://github.com/qdrant/mcp-server-qdrant>)** | This repository is an example of how to create a MCP server for Qdrant, a vector search engine. | ⭐ 1269 | 2026-03-09T08:59:38Z |
 | **[Terraform Server (@hashicorp)](<https://github.com/hashicorp/terraform-mcp-server>)** | Seamlessly integrate with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development powered by [Terraform](https://www.hashicorp.com/en/products/terraform) | ⭐ 1265 | 2026-03-07T16:22:23Z |
-| **[Roundtable (@deadpixel)](<https://github.com/deadpixel/roundtable-dashboard>)** | Multi-model AI debate platform — GPT-4o, Claude, Gemini & 200+ models discuss your prompt, then a moderator synthesizes insight. MCP tools: consult_council, review_code, debug_issue, design_architecture, plan_implementation, assess_tradeoffs. | - | 2026-03-10T00:00:00Z |
+| **[Roundtable (@sinaneshat)](<https://github.com/sinaneshat/roundtable-dashboard>)** | Multi-model AI debate platform — GPT-4o, Claude, Gemini & 200+ models discuss your prompt, then a moderator synthesizes insight. MCP tools: `consult`, `review_code`, `debug`, `architect`, `plan_implementation`, `assess_tradeoffs`. | ⭐ 0 | 2026-03-10T12:00:00Z |
 
 ## Community
 * [Reddit r/mcp](https://www.reddit.com/r/mcp)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The list is automatically updated daily with the latest server information and G
 | **[Mysql (@benborla)](<https://github.com/benborla/mcp-server-mysql>)** | MCP server for providing read-only access to MySQL databases, enabling schema inspection and query execution. | ⭐ 1299 | 2026-03-09T12:19:28Z |
 | **[Qdrant (@qdrant)](<https://github.com/qdrant/mcp-server-qdrant>)** | This repository is an example of how to create a MCP server for Qdrant, a vector search engine. | ⭐ 1269 | 2026-03-09T08:59:38Z |
 | **[Terraform Server (@hashicorp)](<https://github.com/hashicorp/terraform-mcp-server>)** | Seamlessly integrate with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development powered by [Terraform](https://www.hashicorp.com/en/products/terraform) | ⭐ 1265 | 2026-03-07T16:22:23Z |
-| **[Roundtable (@sinaneshat)](<https://github.com/sinaneshat/roundtable-dashboard>)** | Multi-model AI debate platform — GPT-4o, Claude, Gemini & 200+ models discuss your prompt, then a moderator synthesizes insight. MCP tools: `consult_council`, `review_code`, `debug_issue`, `design_architecture`, `plan_implementation`, `assess_tradeoffs`. | ⭐ 0 | 2026-03-10T12:37:47Z |
+| **[Roundtable (@deadpixel)](<https://github.com/deadpixel/roundtable-dashboard>)** | Multi-model AI debate platform — GPT-4o, Claude, Gemini & 200+ models discuss your prompt, then a moderator synthesizes insight. MCP tools: `consult`, `review_code`, `debug`, `architect`, `plan_implementation`, `assess_tradeoffs`. | ⭐ 0 | 2026-03-10 |
 
 ## Community
 * [Reddit r/mcp](https://www.reddit.com/r/mcp)

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ The list is automatically updated daily with the latest server information and G
 | **[Qdrant (@qdrant)](<https://github.com/qdrant/mcp-server-qdrant>)** | This repository is an example of how to create a MCP server for Qdrant, a vector search engine. | ⭐ 1269 | 2026-03-09T08:59:38Z |
 | **[Terraform Server (@hashicorp)](<https://github.com/hashicorp/terraform-mcp-server>)** | Seamlessly integrate with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development powered by [Terraform](https://www.hashicorp.com/en/products/terraform) | ⭐ 1265 | 2026-03-07T16:22:23Z |
 
+| **[Roundtable (@deadpixel)](<https://github.com/deadpixel/roundtable-dashboard>)** | Multi-model AI debate platform — GPT-4o, Claude, Gemini & 200+ models discuss your prompt, then a moderator synthesizes insight. MCP tools: consult, review_code, debug, architect, plan_implementation, assess_tradeoffs. | - | 2026-03-10T00:00:00Z |
+
 ## Community
 * [Reddit r/mcp](https://www.reddit.com/r/mcp)
 * [Discord Server](https://glama.ai/mcp/discord)

--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ The list is automatically updated daily with the latest server information and G
 | **[Mysql (@benborla)](<https://github.com/benborla/mcp-server-mysql>)** | MCP server for providing read-only access to MySQL databases, enabling schema inspection and query execution. | ⭐ 1299 | 2026-03-09T12:19:28Z |
 | **[Qdrant (@qdrant)](<https://github.com/qdrant/mcp-server-qdrant>)** | This repository is an example of how to create a MCP server for Qdrant, a vector search engine. | ⭐ 1269 | 2026-03-09T08:59:38Z |
 | **[Terraform Server (@hashicorp)](<https://github.com/hashicorp/terraform-mcp-server>)** | Seamlessly integrate with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development powered by [Terraform](https://www.hashicorp.com/en/products/terraform) | ⭐ 1265 | 2026-03-07T16:22:23Z |
-
-| **[Roundtable (@deadpixel)](<https://github.com/deadpixel/roundtable-dashboard>)** | Multi-model AI debate platform — GPT-4o, Claude, Gemini & 200+ models discuss your prompt, then a moderator synthesizes insight. MCP tools: consult, review_code, debug, architect, plan_implementation, assess_tradeoffs. | - | 2026-03-10T00:00:00Z |
+| **[Roundtable (@deadpixel)](<https://github.com/deadpixel/roundtable-dashboard>)** | Multi-model AI debate platform — GPT-4o, Claude, Gemini & 200+ models discuss your prompt, then a moderator synthesizes insight. MCP tools: consult_council, review_code, debug_issue, design_architecture, plan_implementation, assess_tradeoffs. | - | 2026-03-10T00:00:00Z |
 
 ## Community
 * [Reddit r/mcp](https://www.reddit.com/r/mcp)


### PR DESCRIPTION
## Add Roundtable MCP Server

**Roundtable** is a multi-model AI debate platform where GPT-4o, Claude, Gemini & 200+ models discuss your question collaboratively, then a moderator synthesizes all perspectives into actionable insight.

- **Repository**: https://github.com/deadpixel/roundtable-dashboard
- **Website**: https://roundtable.now
- **MCP Endpoint**: `https://mcp.roundtable.now/mcp` (Streamable HTTP)
- **Auth**: API Key (`rpnd_` prefix)

### MCP Tools (13 total)

| Tool | Description |
|------|-------------|
| `consult_council` | Multi-model roundtable discussion on any question |
| `review_code` | Multi-perspective code review |
| `debug_issue` | Multi-angle bug diagnosis |
| `design_architecture` | Architecture design council |
| `plan_implementation` | Implementation planning with consensus |
| `assess_tradeoffs` | Evaluate technical tradeoffs |
| `check_usage` | Check credits and rate limits |
| `list_models` | List available AI models |
| `list_sessions` | List past debate sessions |
| `get_session` | Retrieve session results |
| `get_thread_link` | Get shareable thread link |
| `set_thread_visibility` | Toggle thread visibility |
| `get_logs` | View invocation logs |

### Key Features
- Auto-mode: AI picks optimal models, roles, and conversation mode
- Configurable thinking levels (low/medium/high)
- Session persistence and thread sharing
- 3 built-in prompts, 3 resources