### PR TITLE
Add Nucleus MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The list is automatically updated daily with the latest server information and G
 | **[Imcp (@loopwork-ai)](<https://github.com/loopwork-ai/iMCP>)** | A macOS app that provides an MCP server for your iMessage, Reminders, and other Apple services. | ⭐ 1349 | 2026-04-03T04:29:43Z |
 | **[Qdrant (@qdrant)](<https://github.com/qdrant/mcp-server-qdrant>)** | This repository is an example of how to create a MCP server for Qdrant, a vector search engine. | ⭐ 1318 | 2026-04-03T03:35:00Z |
 | **[Gitlab Mcp (@zereight)](<https://github.com/zereight/gitlab-mcp>)** | gitlab mcp | ⭐ 1307 | 2026-04-03T10:22:32Z |
+| **[Nucleus MCP (@eidetic-works)](<https://github.com/eidetic-works/nucleus-mcp>)** | 114 MCP tools for persistent memory, execution verification, governance, and compliance. Local-first. | ⭐ 1 | 2026-04-03T10:19:04Z |
 
 ## Community
 * [Reddit r/mcp](https://www.reddit.com/r/mcp)


### PR DESCRIPTION
## Summary
- Add **Nucleus MCP** server to the list
- Repository: https://github.com/eidetic-works/nucleus-mcp
- 114 MCP tools for persistent memory, execution verification, governance, and compliance. Local-first.

## Server Details
| Field | Value |
|-------|-------|
| Name | Nucleus MCP |
| Repository | https://github.com/eidetic-works/nucleus-mcp |
| License | Apache-2.0 |
| Category | Memory / Governance / Developer Tools |

### Key Features
- **Persistent memory** — local-first `.brain/` knowledge graph that survives across sessions
- **Execution verification** — GROUND loop ensures code actually runs, not just compiles
- **Governance & compliance** — policy enforcement, audit trails, commitment ledger
- **114 tools** across memory, tasks, sessions, orchestration, federation, and more
- **Zero-config** — works out of the box with Claude Code, Cursor, Windsurf, and other MCP clients