### PR TITLE
Add Google Flights MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The list is automatically updated daily with the latest server information and G
 | **[Cognee (@topoteretes)](<https://github.com/topoteretes/cognee>)** | Cognee implements modular pipelines for scalable AI data layer operations, including vector and graph storage for conversational, document, and transcription analysis. | N/A | 2024-12-31T06:51:33Z |
 | **[Coincap Mcp (@QuantGeekDev)](<https://github.com/QuantGeekDev/coincap-mcp>)** | This server allows querying cryptocurrency information from Coincap's public API without requiring API keys or registration. | N/A | 2024-12-31T07:00:00Z |
 | **[Coinmarket Server (@anjor)](<https://github.com/anjor/coinmarket-mcp-server>)** | Coinmarket MCP server is an implementation of a service offering Coinmarket API endpoints for cryptocurrency data, along with custom tools for data extraction like currency listings and token quotes. | N/A | 2024-12-31T06:47:46Z |
+| **[Google Flights Mcp (@mtnrabi)](<https://github.com/mtnrabi/google-flights-mcp>)** | Real-time Google Flights fares — one call searches a whole date range and multiple destination airports, each result carrying Google's own price-insight verdict. Bring your own RapidAPI key. | N/A | None |
 
 ## Community
 * [Reddit r/mcp](https://www.reddit.com/r/mcp)


### PR DESCRIPTION
Adds one row to the MCP Servers table in `README.md` for `mtnrabi/google-flights-mcp`, in alphabetical position after the last current entry.

It is a community server (not affiliated with Google) for real-time Google Flights fares, hosted as a Streamable HTTP endpoint at `https://google-flights-mcp.flightpowers.com/mcp` with exactly two tools, `search_oneway_flights` and `search_roundtrip_flights`. Each call expands a date range and a list of destination airports internally, so a flexible search is one request, and every result carries Google's own price-insight low/typical/high verdict plus a booking link. Auth is bring-your-own RapidAPI key (`x-rapidapi-key` header or `rapidapi_key` query parameter); the source is MIT-licensed Python.

I see the README is regenerated daily by automation from upstream data sources — if this listing belongs in that source instead, happy to submit it wherever you prefer.
